### PR TITLE
Fixed the HorizontalPanelExample Form's Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ First release after migration to GitHub.
 * [Marco Minerva](https://github.com/marcominerva)
 * [Lorenz Cuno Klopfenstein](https://github.com/lorenzck)
 * [Julie Koubová](https://github.com/juliekoubova)
-* Blake Pell
+* [Blake Pell](https:github.com/blakepell)
 * multippt
 * Nicholas Kwan
 * [Enner Pérez](https://github.com/ennerperez)

--- a/src/WindowsFormsAeroShowcase/HorizontalPanelExample.Designer.cs
+++ b/src/WindowsFormsAeroShowcase/HorizontalPanelExample.Designer.cs
@@ -29,9 +29,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HorizontalPanelExample));
             this.panelTop = new System.Windows.Forms.Panel();
-            this.panelDividers = new System.Windows.Forms.Panel();
-            this.labeledDivider4 = new WindowsFormsAero.LabeledDivider();
-            this.labeledDivider3 = new WindowsFormsAero.LabeledDivider();
+            this.label10 = new System.Windows.Forms.Label();
             this.labeledDivider2 = new WindowsFormsAero.LabeledDivider();
             this.labeledDivider1 = new WindowsFormsAero.LabeledDivider();
             this.label9 = new System.Windows.Forms.Label();
@@ -47,7 +45,6 @@
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.panelTop.SuspendLayout();
-            this.panelDividers.SuspendLayout();
             this.layout.SuspendLayout();
             this.panelBottom.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
@@ -55,86 +52,56 @@
             // 
             // panelTop
             // 
-            this.panelTop.Controls.Add(this.panelDividers);
+            this.panelTop.Controls.Add(this.label10);
+            this.panelTop.Controls.Add(this.labeledDivider2);
             this.panelTop.Controls.Add(this.labeledDivider1);
             this.panelTop.Controls.Add(this.label9);
             this.panelTop.Controls.Add(this.label8);
             this.panelTop.Controls.Add(this.label7);
             this.panelTop.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelTop.Location = new System.Drawing.Point(4, 5);
-            this.panelTop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panelTop.Location = new System.Drawing.Point(3, 3);
             this.panelTop.Name = "panelTop";
-            this.panelTop.Size = new System.Drawing.Size(1033, 564);
+            this.panelTop.Size = new System.Drawing.Size(699, 375);
             this.panelTop.TabIndex = 1;
+            this.panelTop.Paint += new System.Windows.Forms.PaintEventHandler(this.PanelTop_Paint);
             // 
-            // panelDividers
+            // label10
             // 
-            this.panelDividers.AutoScroll = true;
-            this.panelDividers.Controls.Add(this.labeledDivider4);
-            this.panelDividers.Controls.Add(this.labeledDivider3);
-            this.panelDividers.Controls.Add(this.labeledDivider2);
-            this.panelDividers.Location = new System.Drawing.Point(46, 287);
-            this.panelDividers.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.panelDividers.Name = "panelDividers";
-            this.panelDividers.Size = new System.Drawing.Size(561, 222);
-            this.panelDividers.TabIndex = 4;
-            // 
-            // labeledDivider4
-            // 
-            this.labeledDivider4.DividerColor = System.Drawing.Color.FromArgb(((int)(((byte)(176)))), ((int)(((byte)(191)))), ((int)(((byte)(222)))));
-            this.labeledDivider4.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
-            this.labeledDivider4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(51)))), ((int)(((byte)(170)))));
-            this.labeledDivider4.Location = new System.Drawing.Point(4, 233);
-            this.labeledDivider4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.labeledDivider4.Name = "labeledDivider4";
-            this.labeledDivider4.Size = new System.Drawing.Size(510, 63);
-            this.labeledDivider4.TabIndex = 2;
-            this.labeledDivider4.Text = "Divider 3";
-            // 
-            // labeledDivider3
-            // 
-            this.labeledDivider3.DividerColor = System.Drawing.Color.FromArgb(((int)(((byte)(176)))), ((int)(((byte)(191)))), ((int)(((byte)(222)))));
-            this.labeledDivider3.DividerPosition = WindowsFormsAero.LabeledDivider.DividerPositions.Below;
-            this.labeledDivider3.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
-            this.labeledDivider3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(51)))), ((int)(((byte)(170)))));
-            this.labeledDivider3.Location = new System.Drawing.Point(4, 128);
-            this.labeledDivider3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.labeledDivider3.Name = "labeledDivider3";
-            this.labeledDivider3.Size = new System.Drawing.Size(510, 63);
-            this.labeledDivider3.TabIndex = 1;
-            this.labeledDivider3.Text = "Divider 2";
+            this.label10.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label10.Location = new System.Drawing.Point(53, 218);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(609, 46);
+            this.label10.TabIndex = 5;
+            this.label10.Text = resources.GetString("label10.Text");
             // 
             // labeledDivider2
             // 
             this.labeledDivider2.DividerColor = System.Drawing.Color.FromArgb(((int)(((byte)(176)))), ((int)(((byte)(191)))), ((int)(((byte)(222)))));
-            this.labeledDivider2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
+            this.labeledDivider2.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labeledDivider2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(51)))), ((int)(((byte)(170)))));
-            this.labeledDivider2.Location = new System.Drawing.Point(4, 17);
-            this.labeledDivider2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labeledDivider2.Location = new System.Drawing.Point(31, 189);
             this.labeledDivider2.Name = "labeledDivider2";
-            this.labeledDivider2.Size = new System.Drawing.Size(510, 63);
-            this.labeledDivider2.TabIndex = 0;
-            this.labeledDivider2.Text = "Divider 1";
+            this.labeledDivider2.Size = new System.Drawing.Size(633, 30);
+            this.labeledDivider2.TabIndex = 4;
+            this.labeledDivider2.Text = "Another Divider:";
             // 
             // labeledDivider1
             // 
             this.labeledDivider1.DividerColor = System.Drawing.Color.FromArgb(((int)(((byte)(176)))), ((int)(((byte)(191)))), ((int)(((byte)(222)))));
             this.labeledDivider1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labeledDivider1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(51)))), ((int)(((byte)(170)))));
-            this.labeledDivider1.Location = new System.Drawing.Point(46, 153);
-            this.labeledDivider1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labeledDivider1.Location = new System.Drawing.Point(31, 110);
             this.labeledDivider1.Name = "labeledDivider1";
-            this.labeledDivider1.Size = new System.Drawing.Size(949, 45);
+            this.labeledDivider1.Size = new System.Drawing.Size(633, 30);
             this.labeledDivider1.TabIndex = 3;
             this.labeledDivider1.Text = "Disclaimer:";
             // 
             // label9
             // 
             this.label9.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label9.Location = new System.Drawing.Point(79, 203);
-            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label9.Location = new System.Drawing.Point(53, 143);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(914, 95);
+            this.label9.Size = new System.Drawing.Size(609, 46);
             this.label9.TabIndex = 2;
             this.label9.Text = "The workstation name below is correct, but the memory and processor are hard code" +
     "d and just for display purposes.";
@@ -142,10 +109,9 @@
             // label8
             // 
             this.label8.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(40, 77);
-            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label8.Location = new System.Drawing.Point(27, 59);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(981, 95);
+            this.label8.Size = new System.Drawing.Size(654, 63);
             this.label8.TabIndex = 1;
             this.label8.Text = resources.GetString("label8.Text");
             // 
@@ -154,27 +120,28 @@
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label7.ForeColor = System.Drawing.SystemColors.HotTrack;
-            this.label7.Location = new System.Drawing.Point(37, 10);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label7.Location = new System.Drawing.Point(25, 15);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(167, 40);
+            this.label7.Size = new System.Drawing.Size(111, 25);
             this.label7.TabIndex = 0;
             this.label7.Text = "Information";
             // 
             // layout
             // 
+            this.layout.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.layout.ColumnCount = 1;
             this.layout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.layout.Controls.Add(this.panelBottom, 0, 1);
             this.layout.Controls.Add(this.panelTop, 0, 0);
-            this.layout.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.layout.Location = new System.Drawing.Point(0, 50);
+            this.layout.Location = new System.Drawing.Point(0, 0);
             this.layout.Margin = new System.Windows.Forms.Padding(0);
             this.layout.Name = "layout";
             this.layout.RowCount = 2;
             this.layout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.layout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 133F));
-            this.layout.Size = new System.Drawing.Size(1041, 707);
+            this.layout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 90F));
+            this.layout.Size = new System.Drawing.Size(705, 471);
             this.layout.TabIndex = 2;
             // 
             // panelBottom
@@ -189,47 +156,43 @@
             this.panelBottom.Controls.Add(this.label1);
             this.panelBottom.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelBottom.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.panelBottom.Location = new System.Drawing.Point(0, 574);
+            this.panelBottom.Location = new System.Drawing.Point(0, 381);
             this.panelBottom.Margin = new System.Windows.Forms.Padding(0);
             this.panelBottom.Name = "panelBottom";
-            this.panelBottom.Size = new System.Drawing.Size(1041, 133);
+            this.panelBottom.Size = new System.Drawing.Size(705, 90);
             this.panelBottom.TabIndex = 4;
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(279, 80);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Location = new System.Drawing.Point(186, 53);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(59, 25);
+            this.label6.Size = new System.Drawing.Size(38, 15);
             this.label6.TabIndex = 6;
             this.label6.Text = "label6";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(279, 48);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Location = new System.Drawing.Point(186, 32);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(59, 25);
+            this.label5.Size = new System.Drawing.Size(38, 15);
             this.label5.TabIndex = 5;
             this.label5.Text = "label5";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(279, 15);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Location = new System.Drawing.Point(186, 10);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(59, 25);
+            this.label4.Size = new System.Drawing.Size(38, 15);
             this.label4.TabIndex = 4;
             this.label4.Text = "label4";
             // 
             // pictureBox1
             // 
             this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
-            this.pictureBox1.Location = new System.Drawing.Point(19, 15);
-            this.pictureBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.pictureBox1.Location = new System.Drawing.Point(13, 10);
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.Size = new System.Drawing.Size(48, 48);
             this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
@@ -240,10 +203,9 @@
             // 
             this.label3.AutoSize = true;
             this.label3.ForeColor = System.Drawing.SystemColors.InactiveCaptionText;
-            this.label3.Location = new System.Drawing.Point(164, 80);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Location = new System.Drawing.Point(109, 53);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(93, 25);
+            this.label3.Size = new System.Drawing.Size(61, 15);
             this.label3.TabIndex = 2;
             this.label3.Text = "Processor:";
             // 
@@ -251,10 +213,9 @@
             // 
             this.label2.AutoSize = true;
             this.label2.ForeColor = System.Drawing.SystemColors.InactiveCaptionText;
-            this.label2.Location = new System.Drawing.Point(174, 48);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(116, 32);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 25);
+            this.label2.Size = new System.Drawing.Size(55, 15);
             this.label2.TabIndex = 1;
             this.label2.Text = "Memory:";
             // 
@@ -262,30 +223,27 @@
             // 
             this.label1.AutoSize = true;
             this.label1.ForeColor = System.Drawing.SystemColors.InactiveCaptionText;
-            this.label1.Location = new System.Drawing.Point(143, 15);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(95, 10);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(112, 25);
+            this.label1.Size = new System.Drawing.Size(74, 15);
             this.label1.TabIndex = 0;
             this.label1.Text = "Workstation:";
             // 
             // HorizontalPanelExample
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1041, 757);
+            this.ClientSize = new System.Drawing.Size(705, 471);
             this.Controls.Add(this.layout);
             this.GlassMargins = new System.Windows.Forms.Padding(0, 0, 50, 0);
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.MinimumSize = new System.Drawing.Size(1055, 746);
+            this.MinimumSize = new System.Drawing.Size(709, 510);
             this.Name = "HorizontalPanelExample";
-            this.Padding = new System.Windows.Forms.Padding(0, 50, 0, 0);
+            this.Padding = new System.Windows.Forms.Padding(0, 33, 0, 0);
             this.Text = "Horizontal panel example";
             this.Load += new System.EventHandler(this.HorizontalPanelExample_Load);
             this.panelTop.ResumeLayout(false);
             this.panelTop.PerformLayout();
-            this.panelDividers.ResumeLayout(false);
             this.layout.ResumeLayout(false);
             this.panelBottom.ResumeLayout(false);
             this.panelBottom.PerformLayout();
@@ -301,10 +259,6 @@
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.Label label9;
         private WindowsFormsAero.LabeledDivider labeledDivider1;
-        private System.Windows.Forms.Panel panelDividers;
-        private WindowsFormsAero.LabeledDivider labeledDivider4;
-        private WindowsFormsAero.LabeledDivider labeledDivider3;
-        private WindowsFormsAero.LabeledDivider labeledDivider2;
         private System.Windows.Forms.TableLayoutPanel layout;
         private WindowsFormsAero.HorizontalPanel panelBottom;
         private System.Windows.Forms.Label label6;
@@ -314,5 +268,7 @@
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label10;
+        private WindowsFormsAero.LabeledDivider labeledDivider2;
     }
 }

--- a/src/WindowsFormsAeroShowcase/HorizontalPanelExample.Designer.cs
+++ b/src/WindowsFormsAeroShowcase/HorizontalPanelExample.Designer.cs
@@ -63,7 +63,6 @@
             this.panelTop.Name = "panelTop";
             this.panelTop.Size = new System.Drawing.Size(699, 375);
             this.panelTop.TabIndex = 1;
-            this.panelTop.Paint += new System.Windows.Forms.PaintEventHandler(this.PanelTop_Paint);
             // 
             // label10
             // 

--- a/src/WindowsFormsAeroShowcase/HorizontalPanelExample.cs
+++ b/src/WindowsFormsAeroShowcase/HorizontalPanelExample.cs
@@ -14,5 +14,9 @@ namespace WindowsFormsAeroShowcase {
             label6.Text = "Intel(R) Pentium(R) 4 CPU 3.40 Ghz (Quad Core)";
         }
 
+        private void PanelTop_Paint(object sender, System.Windows.Forms.PaintEventArgs e)
+        {
+
+        }
     }
 }

--- a/src/WindowsFormsAeroShowcase/HorizontalPanelExample.cs
+++ b/src/WindowsFormsAeroShowcase/HorizontalPanelExample.cs
@@ -9,14 +9,10 @@ namespace WindowsFormsAeroShowcase {
         }
 
         private void HorizontalPanelExample_Load(object sender, EventArgs e) {
-            label4.Text = Environment.MachineName.ToString();
+            label4.Text = Environment.MachineName;
             label5.Text = "3.00 GB";
             label6.Text = "Intel(R) Pentium(R) 4 CPU 3.40 Ghz (Quad Core)";
         }
 
-        private void PanelTop_Paint(object sender, System.Windows.Forms.PaintEventArgs e)
-        {
-
-        }
     }
 }

--- a/src/WindowsFormsAeroShowcase/HorizontalPanelExample.resx
+++ b/src/WindowsFormsAeroShowcase/HorizontalPanelExample.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="label10.Text" xml:space="preserve">
+    <value>Lorem ipsum dolor sit amet consectetur, adipiscing elit porta sollicitudin dui placerat, pellentesque magnis ligula fames. Primis mus placerat condimentum elementum bibendum lacinia, congue nisl vel donec commodo, morbi himenaeos molestie mi quis. Accumsan convallis facilisi ante faucibus conubia porttitor vivamus lobortis et malesuada, quis praesent quam quisque sociosqu auctor dui litora consequat.</value>
+  </data>
   <data name="label8.Text" xml:space="preserve">
     <value>The below is an example of the horizontal panel like is seen in the Computer dialog of Windows 7 and Windows Vista.    This can be used to display additional information for the form that you are currently on.</value>
   </data>


### PR DESCRIPTION
There was a black square in the upper right hand corner of this form, additionally the table layout panel was pushed down by about 33 pixels making for an awkward gap.  Pulled those back up and put the layout dividers back on so they render across the span of the form.

Fun to see code I messed around with 10 years ago still out there.